### PR TITLE
Mainly porting to Linux and some test fixes.

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 import itertools
+import os
 import signal
 import socket
 import subprocess

--- a/tests.py
+++ b/tests.py
@@ -54,7 +54,7 @@ def client(port):
 def mock_server(port):
     with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
         s.bind(("127.0.0.1", port))
-        s.listen()
+        s.listen(4)
         yield s
 
 
@@ -110,6 +110,11 @@ class TestServer(unittest.TestCase):
             msg = a.recv(1)
         except socket.timeout:
             is_closed = False
+        except socket.error as e:
+            if e.errno == 104:
+                is_closed = True
+            else:
+                raise e
         else:
             is_closed = True
             if msg != b"":

--- a/tests.py
+++ b/tests.py
@@ -19,12 +19,12 @@ MAX_MESSAGE_LEN = 1000
 
 def run_client(port, pipe_stderr: bool=False):
     stderr = subprocess.PIPE if pipe_stderr else None
-    return subprocess.Popen(["../build/client", "127.0.0.1", str(port)],
+    return subprocess.Popen(["../zad1/client", "127.0.0.1", str(port)],
                             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=stderr)
 
 
 def run_server(port):
-    return subprocess.Popen(["../build/server", str(port)],
+    return subprocess.Popen(["../zad1/server", str(port)],
                             stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 
 

--- a/tests.py
+++ b/tests.py
@@ -38,7 +38,7 @@ def server(port):
         try:
             p.terminate()
         except os.error as e:
-            if e.errno != 3:
+            if e.errno != errno.ESRCH:
                 raise e
         p.stdout.close()
         p.stdin.close()

--- a/tests.py
+++ b/tests.py
@@ -1,3 +1,4 @@
+import errno
 import itertools
 import os
 import signal
@@ -18,12 +19,12 @@ MAX_MESSAGE_LEN = 1000
 
 def run_client(port, pipe_stderr: bool=False):
     stderr = subprocess.PIPE if pipe_stderr else None
-    return subprocess.Popen(["../zad1/client", "127.0.0.1", str(port)],
+    return subprocess.Popen(["../build/client", "127.0.0.1", str(port)],
                             stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=stderr)
 
 
 def run_server(port):
-    return subprocess.Popen(["../zad1/server", str(port)],
+    return subprocess.Popen(["../build/server", str(port)],
                             stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 
 
@@ -116,7 +117,7 @@ class TestServer(unittest.TestCase):
         except socket.timeout:
             is_closed = False
         except socket.error as e:
-            if e.errno == 104:
+            if e.errno == errno.ECONNRESET:
                 is_closed = True
             else:
                 raise e
@@ -189,7 +190,7 @@ class TestClient(unittest.TestCase):
                 self.assertIsNone(p.poll())
 
         ret = p.wait()
-        self.assertEqual(ret, 0)
+        self.assertEqual(ret, 100)
 
     def test_end_input(self):
         """Client should disconnect after EOF."""

--- a/tests.py
+++ b/tests.py
@@ -33,7 +33,11 @@ def server(port):
         time.sleep(QUANT_SECONDS)
         yield p
     finally:
-        p.terminate()
+        try:
+            p.terminate()
+        except os.error as e:
+            if e.errno != 3:
+                raise e
         p.stdout.close()
         p.stdin.close()
         p.wait()
@@ -234,7 +238,7 @@ class TestClient(unittest.TestCase):
             with s.accept()[0] as k:
                 c.communicate(b"a" * (MAX_MESSAGE_LEN + 1))
                 sent = k.recv(2000)
-                self.assertEqual(sent, prepare_message(b"a" * 1000) + prepare_message(b"a"))
+                self.assertIn(sent, {prepare_message(b"a" * 1000) + prepare_message(b"a"), prepare_message(b"a"*1000)})
                 ret = c.wait()
                 self.assertEqual(ret, 0)
 


### PR DESCRIPTION
- Correctly detecting disconnection of network socket.
- Fixed socket.listen (needs queue length).
- Fixed termination of server on Linux
- Added possibility to cut too long message instead of splitting it.
- When server closes connection, client should return with code 100.
